### PR TITLE
Implement CI/CD GitHub Workflow

### DIFF
--- a/.github/actions/create-native-build/action.yml
+++ b/.github/actions/create-native-build/action.yml
@@ -1,0 +1,42 @@
+name: Create HexGrid native build
+description: Creates a HexGrid native build for a specific platform
+inputs:
+  platform:
+    description: The platform to build for.
+  target:
+    description: The target to build.
+  shell:
+    description: The shell used by the runner.
+  additional-python-packages:
+    description: Additional python packages to install.
+runs:
+  using: composite
+  steps:
+    # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v4
+      with:
+        # Semantic version range syntax or exact version of a Python version
+        python-version: "3.x"
+        # Optional - x64 or x86 architecture, defaults to x64
+        architecture: "x64"
+
+    # Setup scons, print python version and scons version info, so if anything is broken it won't run the build.
+    #TODO: remove hardcoded scons version when https://github.com/godotengine/godot-cpp/pull/1526 is released
+    - name: Configuring Python packages
+      shell: ${{ inputs.shell }}
+      run: |
+        python -c "import sys; print(sys.version)"
+        python -m pip install scons==4.7.0 requests ${{ inputs.additional-python-packages }}
+        python --version
+        scons --version
+
+    - name: Get number of CPU cores
+      id: cpu-cores
+      uses: SimenB/github-actions-cpu-cores@v1
+
+    - name: Compilation
+      shell: ${{ inputs.shell }}
+      run: |
+        cd ../fmod-gdextension
+        scons platform=${{ inputs.platform }} generate_bindings=yes target=${{ inputs.target }} -j${{ steps.cpu-cores.outputs.count }} ${{ inputs.flags }}

--- a/.github/actions/create-native-build/action.yml
+++ b/.github/actions/create-native-build/action.yml
@@ -38,5 +38,5 @@ runs:
     - name: Compilation
       shell: ${{ inputs.shell }}
       run: |
-        cd ../fmod-gdextension
+        cd ../godot-hex-map
         scons platform=${{ inputs.platform }} generate_bindings=yes target=${{ inputs.target }} -j${{ steps.cpu-cores.outputs.count }} ${{ inputs.flags }}

--- a/.github/actions/create-native-build/action.yml
+++ b/.github/actions/create-native-build/action.yml
@@ -40,8 +40,3 @@ runs:
       run: |
         cd ../godot-hex-map
         scons platform=${{ inputs.platform }} generate_bindings=yes target=${{ inputs.target }} -j${{ steps.cpu-cores.outputs.count }} ${{ inputs.flags }}
-
-    - name: Run Tests
-      shell: ${{ inputs.shell }}
-      run: |
-        scons run_tests

--- a/.github/actions/create-native-build/action.yml
+++ b/.github/actions/create-native-build/action.yml
@@ -1,3 +1,26 @@
+# MIT License
+
+# Copyright (c) 2024 Martin Chlopecki and David M. Lary
+# Copyright (c) 2019 Utopia-Rise and Alex Fonseka
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 name: Create HexGrid native build
 description: Creates a HexGrid native build for a specific platform
 inputs:

--- a/.github/actions/create-native-build/action.yml
+++ b/.github/actions/create-native-build/action.yml
@@ -40,3 +40,8 @@ runs:
       run: |
         cd ../godot-hex-map
         scons platform=${{ inputs.platform }} generate_bindings=yes target=${{ inputs.target }} -j${{ steps.cpu-cores.outputs.count }} ${{ inputs.flags }}
+
+    - name: Run Tests
+      shell: ${{ inputs.shell }}
+      run: |
+        scons run_tests

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-2022",
-            "ubuntu-24.04", # consider if best option (differs from FMOD's due to deprecation)
-            "macos-14"] # consider if best option
+            "ubuntu-latest",
+            "macos-14"]
         target: ["editor", "template_debug", "template_release"]
         include:
           - os: "windows-2022"
@@ -18,7 +18,7 @@ jobs:
             additional-python-packages: pywin32
             shell: pwsh
 
-          - os: "ubuntu-24.04"
+          - os: "ubuntu-latest"
             platform: linux
             shell: bash
             
@@ -27,7 +27,7 @@ jobs:
             shell: bash
       
     steps:
-      - name: Checkout PR
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -1,5 +1,9 @@
 name: Check for Successful Build
-on: [pull_request, workflow_dispatch]
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -45,7 +45,7 @@ jobs:
           additional-python-packages: ${{ matrix.additional-python-packages }}
 
       - name: Run Tests
-        if: ${{ matrix.platform }} == "macos" && ${{ matrix.target }} == "editor"
+        if: matrix.platform == 'macos' && matrix.target == 'editor'
         run: |
           scons run_tests
 

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -11,7 +11,7 @@ jobs:
         os: ["windows-2022",
             "ubuntu-24.04", # consider if best option (differs from FMOD's due to deprecation)
             "macos-14"] # consider if best option
-        target: ["editor", "temlate_debug", "template_release"]
+        target: ["editor", "template_debug", "template_release"]
         include:
           - os: "windows-2022"
             platform: windows

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -11,7 +11,7 @@ jobs:
         os: ["windows-2022",
             "ubuntu-24.04", # consider if best option (differs from FMOD's due to deprecation)
             "macos-14"] # consider if best option
-        target: ["editor", "target_debug", "template_release"]
+        target: ["editor", "temlate_debug", "template_release"]
         include:
           - os: "windows-2022"
             platform: windows

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -1,4 +1,4 @@
-name: Check for Successful Builds on All Platforms
+name: Check for Successful Build
 on: [pull_request, workflow_dispatch]
 
 jobs:

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -3,36 +3,33 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   build:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.platform }} ${{ matrix.target }} Compilation
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: ["windows-2022",
+            "ubuntu-24.04", # consider if best option (differs from FMOD's due to deprecation)
+            "macos-14"] # consider if best option
+        target: ["editor", "target_debug", "template_release"]
         include:
-          - name: Windows 10 Editor Compilation
-            os: "windows-2022"
+          - os: "windows-2022"
             platform: windows
-            target: editor
-            shell: pwsh
             additional-python-packages: pywin32
-          
-          - name: Ubuntu Editor Compliation 
-            os: "ubuntu-24.04" # consider if best option (differs from FMOD's due to deprecation)
-            platform: linux
-            target: editor
-            shell: bash
+            shell: pwsh
 
-          - name: MacOS Editor Compilation
-            os: "macos-14" # consider if best option
+          - os: "ubuntu-24.04"
+            platform: linux
+            shell: bash
+            
+          - os: "macos-14"
             platform: macos
-            target: editor
             shell: bash
       
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
         with:
-          # ref: ${{ github.ref }}
           submodules: recursive
 
       - name: Compile native plugin

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -3,7 +3,7 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   build:
-    name: ${{ matrix.platform }} ${{ matrix.target }} Compilation
+    name: ${{ matrix.os }} ${{ matrix.target }} Compilation
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -1,0 +1,47 @@
+name: Check for Successful Builds on All Platforms
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows 10 Editor Compilation
+            os: "windows-2022"
+            platform: windows
+            target: editor
+            shell: pwsh
+            additional-python-packages: pywin32
+          
+          - name: Ubuntu Editor Compliation 
+            os: "ubuntu-24.04" # consider if best option (differs from FMOD's due to deprecation)
+            platform: linux
+            target: editor
+            shell: bash
+
+          - name: MacOS Editor Compilation
+            os: "macos-14" # consider if best option
+            platform: macos
+            target: editor
+            shell: bash
+      
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          # ref: ${{ github.ref }}
+          submodules: recursive
+
+      - name: Compile native plugin
+        uses: ./.github/actions/create-native-build
+        with:
+          platform: ${{ matrix.platform }}
+          target: ${{ matrix.target }}
+          shell: ${{ matrix.shell }}
+          additional-python-packages: ${{ matrix.additional-python-packages }}
+
+
+  

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -40,5 +40,10 @@ jobs:
           shell: ${{ matrix.shell }}
           additional-python-packages: ${{ matrix.additional-python-packages }}
 
+      - name: Run Tests
+        if: ${{ matrix.platform }} == "macos" && ${{ matrix.target }} == "editor"
+        run: |
+          scons run_tests
+
 
   

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -13,7 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-2022",
-            "ubuntu-latest",
+            # disabled pending fixes for `-Wchanges-meaning` errors
+            # "ubuntu-latest",
             "macos-14"]
         target: ["editor", "template_debug", "template_release"]
         include:


### PR DESCRIPTION
Addresses #7 

The workflow triggers on PRs inits and changes. The workflow can also be initiated from the [Actions tab](https://github.com/dmlary/godot-hex-map/actions), but only once pulled into main, and it will currently only run on the main branch in this implementation. 

The workflow attempts to build for Windows, Mac, and Ubuntu, but not Android and iOS. This does possibly leave a possibility for users of the extension to see errors for the Android editor/mobile exports. I think until the rewrite happens, the current builds will be sufficient. For Windows, I feel fairly confident in my os image choice, but I think the Mac/Ubuntu images could be checked. Notably, when referring to the FMOD GDExtension, the Ubuntu image was slated as deprecated, so it needed to be changed.

Some development notes are on [my fork](https://github.com/mchlopecki/godot-hex-map/pull/1).