### PR TITLE
fix: Fix cell labelling in sandbox

### DIFF
--- a/demo/RayPickerCamera/ray_picker_camera.gd
+++ b/demo/RayPickerCamera/ray_picker_camera.gd
@@ -49,23 +49,31 @@ func _ready() -> void:
 
     # label all of the cells
     if label_cells == true:
+        var max_neighbour_search_height = 5
+        var label_string = "q:{q}, r:{r}, y:{y}"
+
         for cell_vec in hex_map.get_cell_vecs():
             var cell := HexMapCellId.from_vec(cell_vec)
-
+            var is_top_cell = true
+            var current_search_height = 0
             var above = cell
-            above.y += 1
-            if hex_map.get_cell_item(above) != -1:
+            while is_top_cell && current_search_height <= max_neighbour_search_height:
+                above = above.up()
+                is_top_cell = hex_map.get_cell(above)["value"] == HexMapNode.CELL_VALUE_NONE
+                current_search_height += 1
+
+            if !is_top_cell:
                 continue
 
-            var coords = hex_map.cell_id_to_local(cell);
+            var coords = hex_map.get_cell_center(cell);
             var clabel := Label3D.new();
             clabel.no_depth_test = true
-            clabel.text = str(cell)
-            coords.y += 0.5
+            clabel.text = label_string.format({ "q": cell.q, "r": cell.r, "y": cell.y })
+            coords.y += 0.75
             clabel.position = coords
             clabel.billboard = BaseMaterial3D.BILLBOARD_ENABLED
-            clabel.font_size = 64
-            clabel.outline_size = 0
+            clabel.font_size = 48
+            clabel.outline_size = 3
             clabel.modulate = Color.BLACK
             get_parent().add_child.call_deferred(clabel)
 

--- a/demo/RayPickerCamera/ray_picker_camera.gd
+++ b/demo/RayPickerCamera/ray_picker_camera.gd
@@ -59,7 +59,7 @@ func _ready() -> void:
             var above = cell
             while is_top_cell && current_search_height <= max_neighbour_search_height:
                 above = above.up()
-                is_top_cell = hex_map.get_cell(above)["value"] == HexMapNode.CELL_VALUE_NONE
+                is_top_cell = !hex_map.has(above)
                 current_search_height += 1
 
             if !is_top_cell:

--- a/demo/RayPickerCamera/ray_picker_camera.gd
+++ b/demo/RayPickerCamera/ray_picker_camera.gd
@@ -65,12 +65,11 @@ func _ready() -> void:
             if !is_top_cell:
                 continue
 
-            var coords = hex_map.get_cell_center(cell);
+            var coords_above = hex_map.get_cell_center(cell.up());
             var clabel := Label3D.new();
             clabel.no_depth_test = true
             clabel.text = label_string.format({ "q": cell.q, "r": cell.r, "y": cell.y })
-            coords.y += 0.75
-            clabel.position = coords
+            clabel.position = coords_above
             clabel.billboard = BaseMaterial3D.BILLBOARD_ENABLED
             clabel.font_size = 48
             clabel.outline_size = 3

--- a/src/core/cell_id.h
+++ b/src/core/cell_id.h
@@ -119,7 +119,7 @@ public:
             bool include_center = false) const;
 
     // get the pixel center of this cell assuming the cell is a unit cell with
-    // height = 1, radius = 1.  Use HexMap.map_to_local() for center scaled
+    // height = 1, radius = 1.  Use HexMap.get_cell_center() for center scaled
     // by cell size.
     Vector3 unit_center() const;
 


### PR DESCRIPTION
Hi, thank you very much for your work on this package. Hoping I can contribute.

While trying the demo, I noticed some references to `HexMap` methods in `ray_picker_camera.gd` that don't seem to exist (anymore?) - [`HexMap.get_cell_item`](https://github.com/dmlary/godot-hex-map/blob/153b21860f31a64626beac765625693c7fc5fed7/demo/RayPickerCamera/ray_picker_camera.gd#L57) and [`HexMap.cell_id_to_local`](https://github.com/dmlary/godot-hex-map/blob/153b21860f31a64626beac765625693c7fc5fed7/demo/RayPickerCamera/ray_picker_camera.gd#L60). These are referenced as part of the "Label Cells" functionality, and cause errors while "Label Cells" is enabled.

This is an attempt to fix that functionality, and improve the display of the labels. I've expanded the "above" neighbour check to avoid labelling cells that don't have a direct neighbour above them but might have one in some small search space, and I've tried to make the labels a little easier to read.

Before:
![cell labels - before](https://github.com/user-attachments/assets/92080f22-b630-4968-a4a9-2724c17fbf26)

After:
![cell labels - after](https://github.com/user-attachments/assets/9b30dafb-63e1-4a7e-81ec-aea2bfd7a016)

Separately, I also noticed a reference to [`HexMap.map_to_local`](https://github.com/dmlary/godot-hex-map/blob/153b21860f31a64626beac765625693c7fc5fed7/src/core/cell_id.h#L122) in a code comment, which also doesnt seem to exist. I've updated that to what I think is the appropriate method.