### PR TITLE
feat: Add release archive workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,106 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+      concurrency-group:
+        type: string
+        required: true
+      float-precision:
+        type: string
+        default: single
+      artifact-name:
+        type: string
+        default: hex_map
+    outputs:
+      artifact-name:
+        value: ${{ inputs.artifact-name }}
+
+env:
+  # Use UTF-8 on Linux.
+  LANG: en_US.UTF-8
+  LC_ALL: en_US.UTF-8
+
+concurrency:
+  group: ${{ inputs.concurrency-group }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build GDExtension
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          [
+            { platform: linux, arch: x86_64, os: ubuntu-22.04 },
+            { platform: windows, arch: x86_64, os: windows-latest },
+            { platform: windows, arch: x86_32, os: windows-latest },
+            { platform: macos, arch: universal, os: macos-latest },
+            { platform: android, arch: arm64, os: ubuntu-22.04 },
+            { platform: android, arch: arm32, os: ubuntu-22.04 },
+            { platform: android, arch: x86_64, os: ubuntu-22.04 },
+            { platform: android, arch: x86_32, os: ubuntu-22.04 },
+            { platform: ios, arch: arm64, os: macos-latest },
+            { platform: web, arch: wasm32, os: ubuntu-22.04 }
+          ]
+        target-type: [editor, template_debug, template_release]
+
+    runs-on: ${{ matrix.target.os }}
+    env:
+      BUILD_VERSION: ${{ matrix.target.platform }}_${{ matrix.target.arch }}_${{ inputs.float-precision }}_${{ matrix.target-type }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: true
+
+      - name: Setup godot-cpp build environment
+        uses: godotengine/godot-cpp/.github/actions/setup-godot-cpp@godot-4.4-stable
+        with:
+          platform: ${{ matrix.target.platform }}
+          em-version: 3.1.62
+
+      - name: Restore Scons cache
+        uses: godotengine/godot-cpp/.github/actions/godot-cache-restore@godot-4.4-stable
+        with:
+          scons-cache: ${{ github.workspace }}/.scons-cache/
+          cache-name: scons_cache-${{ env.BUILD_VERSION }}_${{ hashFiles('.gitmodules') }}
+
+      - name: Build GDExtension
+        shell: sh
+        env:
+          SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
+        run: |
+          scons \
+            verbose=1 \
+            target=${{ matrix.target-type }} \
+            platform=${{ matrix.target.platform }} \
+            arch=${{ matrix.target.arch }} \
+            precision=${{ inputs.float-precision }}
+
+      - name: Save Scons cache
+        uses: godotengine/godot-cpp/.github/actions/godot-cache-save@godot-4.4-stable
+        with:
+          scons-cache: ${{ github.workspace }}/.scons-cache/
+          cache-name: scons_cache-${{ env.BUILD_VERSION }}_${{ hashFiles('.gitmodules') }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}-${{ env.BUILD_VERSION }}_${{ hashFiles('.gitmodules') }}
+          path: ${{ github.workspace }}/demo/addons/hex_map/
+
+  merge:
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          pattern: ${{ inputs.artifact-name }}-*
+          delete-merged: true
+          retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build GDExtension
+    uses: ./.github/workflows/build.yml
+    with:
+      concurrency-group: ${{ inputs.tag || github.event.release.tag_name }}
+
+  archive:
+    needs: build
+    name: Create & Upload Archive
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+      BUILD_ARTIFACT_NAME: ${{ needs.build.outputs.artifact-name }}
+      BUILD_ARTIFACT_PATH: addons/${{ needs.build.outputs.artifact-name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          # We only need the .git folder, but it's not supported yet (https://github.com/actions/checkout/issues/603).
+          # This minimises what's checked out.
+          sparse-checkout: .github
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.BUILD_ARTIFACT_NAME }}
+          path: ${{ env.BUILD_ARTIFACT_PATH }}
+      - id: create-archive
+        name: Create Archive
+        shell: sh
+        env:
+          ARCHIVE_NAME: ${{ env.BUILD_ARTIFACT_NAME }}-${{ env.RELEASE_TAG }}.tar.gz
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Creating $ARCHIVE_NAME from ${{ env.BUILD_ARTIFACT_PATH }}"
+          tar -czvf $ARCHIVE_NAME ${{ env.BUILD_ARTIFACT_PATH }}
+          echo "Uploading $ARCHIVE_NAME to release ${{ env.RELEASE_TAG }}"
+          gh release upload ${{ env.RELEASE_TAG }} $ARCHIVE_NAME


### PR DESCRIPTION
- Adds a `build` workflow, copying jobs/steps from the CI workflow, which builds the extension for all targets then uploads and merges their artifacts
- Adds a `release` workflow, which builds the extension using the above workflow for a given release tag, adds everything under `demo/addons/hex_map` (including all the resulting lib files) into a gziped tar, then uploads the resulting tar to the GitHub release for said tag

The release workflow is triggered by release publish, or can be triggered manually. (Not sure if that's how you actually want to handle producing the archive, so can be changed easily.)

Example of a successful run at https://github.com/m-orchard/godot-hex-map/actions/runs/15935678460, which added the archive (hex_map-v1.0.0.tar.gz) at https://github.com/m-orchard/godot-hex-map/releases/tag/v1.0.0.