### PR TITLE
WIP: Remove HexMapCellId::operator Variant()

### DIFF
--- a/src/core/cell_id.h
+++ b/src/core/cell_id.h
@@ -72,7 +72,6 @@ public:
     // vector3i is the fastest way to get to a Variant type that isn't malloc
     // heavy (like Ref<HexMapCellIdRef>)
     inline operator Vector3i() const { return Vector3i(q, y, r); }
-    inline operator Variant() const { return (Vector3i) * this; }
     operator String() const;
 
     /// return a Ref<T> wrapped copy of this HexMapCellId

--- a/src/core/editor/editor_plugin.cpp
+++ b/src/core/editor/editor_plugin.cpp
@@ -270,7 +270,7 @@ void HexMapNodeEditorPlugin::selection_move() {
     size_t index = 0;
     for (const HexMapCellId &cell_id : selection_manager->get_cell_ids()) {
         size_t base = index * HexMapNode::CELL_ARRAY_WIDTH;
-        cells[base] = cell_id;
+        cells[base] = cell_id.to_vec();
         cells[base + HexMapNode::CELL_ARRAY_INDEX_VALUE] =
                 HexMapNode::CELL_VALUE_NONE;
         index++;
@@ -493,7 +493,7 @@ int32_t HexMapNodeEditorPlugin::_forward_3d_gui_input(Camera3D *p_camera,
             static_assert(HexMapNode::CELL_ARRAY_INDEX_VEC == 0);
             static_assert(HexMapNode::CELL_ARRAY_INDEX_VALUE == 1);
             static_assert(HexMapNode::CELL_ARRAY_INDEX_ORIENTATION == 2);
-            hex_map->set_cells(Array::make(cell_id, -1, 0));
+            hex_map->set_cells(Array::make(cell_id.to_vec(), -1, 0));
         }
         if (mouse_right_released) {
             commit_cell_changes("HexMap: erase cells");

--- a/src/core/editor/selection_manager.cpp
+++ b/src/core/editor/selection_manager.cpp
@@ -135,7 +135,7 @@ Vector<HexMapCellId> SelectionManager::get_cell_ids() const {
 Array SelectionManager::get_cell_vecs() const {
     Array out;
     for (const auto &cell : mesh_manager.get_cells()) {
-        out.push_back((CellId)cell.key);
+        out.push_back(((CellId)cell.key).to_vec());
     }
     return out;
 }

--- a/src/core/hex_map_node.cpp
+++ b/src/core/hex_map_node.cpp
@@ -233,7 +233,7 @@ Array HexMapNode::get_cell_ids_in_local_quad(Vector3 a,
     Array out;
     out.resize(count);
     for (int i = 0; i < count; i++) {
-        out[i] = Ref<hex_bind::HexMapCellId>(cell_ids[i]);
+        out[i] = cell_ids[i].to_ref();
     }
     return out;
 }


### PR DESCRIPTION
Remove the implicit conversion from HexMapCellId to Ref<hex_base::HexMapCellId> via `Variant`.  The result was returning nulls in `HexMapNode.get_cell_ids_in_local_quad()`.

Need to add gdscript tests for `HexMapNode.get_cell_ids_in_local_quad()`.

fixes #36