### PR TITLE
Auto-generate a preview texture from the mesh if no preview is provided.

### DIFF
--- a/demo/addons/hex_map/gui/auto_tiled_rule_editor.gd
+++ b/demo/addons/hex_map/gui/auto_tiled_rule_editor.gd
@@ -152,6 +152,7 @@ func _on_mesh_library_changed() -> void:
         %MeshPalette.add_item({
             "id": id,
             "preview": mesh_library.get_item_preview(id),
+            "mesh": mesh_library.get_item_mesh(id),
             "desc": mesh_library.get_item_name(id),
         })
 

--- a/demo/addons/hex_map/gui/auto_tiled_rule_editor.gd
+++ b/demo/addons/hex_map/gui/auto_tiled_rule_editor.gd
@@ -149,10 +149,12 @@ func _on_cell_types_changed() -> void:
 func _on_mesh_library_changed() -> void:
     %MeshPalette.clear()
     for id in mesh_library.get_item_list():
+        var preview = mesh_library.get_item_preview(id)
+        if not preview:
+            preview = EditorInterface.make_mesh_previews([mesh_library.get_item_mesh(id)], 128)[0]
         %MeshPalette.add_item({
             "id": id,
-            "preview": mesh_library.get_item_preview(id),
-            "mesh": mesh_library.get_item_mesh(id),
+            "preview": preview,
             "desc": mesh_library.get_item_name(id),
         })
 

--- a/demo/addons/hex_map/gui/hex_map_editor_bottom_panel.gd
+++ b/demo/addons/hex_map/gui/hex_map_editor_bottom_panel.gd
@@ -58,6 +58,7 @@ func _on_node_mesh_library_changed() -> void:
         %MeshPalette.add_item({
             "id": id,
             "preview": mesh_library.get_item_preview(id),
+            "mesh": mesh_library.get_item_mesh(id),
             "desc": mesh_library.get_item_name(id),
         })
 

--- a/demo/addons/hex_map/gui/hex_map_editor_bottom_panel.gd
+++ b/demo/addons/hex_map/gui/hex_map_editor_bottom_panel.gd
@@ -55,10 +55,12 @@ func _on_node_mesh_library_changed() -> void:
     %MeshPalette.clear()
     var mesh_library := node.mesh_library
     for id in mesh_library.get_item_list():
+        var preview = mesh_library.get_item_preview(id)
+        if not preview:
+            preview = EditorInterface.make_mesh_previews([mesh_library.get_item_mesh(id)], 128)[0]
         %MeshPalette.add_item({
             "id": id,
-            "preview": mesh_library.get_item_preview(id),
-            "mesh": mesh_library.get_item_mesh(id),
+            "preview": preview,
             "desc": mesh_library.get_item_name(id),
         })
 

--- a/demo/addons/hex_map/gui/palette.gd
+++ b/demo/addons/hex_map/gui/palette.gd
@@ -227,6 +227,12 @@ func populate_compact_palette() -> void:
             button.color = Color.TRANSPARENT
             button.selected = id == selected_id
             button.tooltip_text = item.desc
+        elif item.mesh is Mesh:
+			button = PaletteChip.new()
+			button.preview = EditorInterface.make_mesh_previews([item.mesh], 128)[0]
+			button.color = Color.TRANSPARENT
+			button.selected = id == selected_id
+			button.tooltip_text = item.desc
         else:
             push_error("invalid type for item.preview: ", item)
 
@@ -250,6 +256,9 @@ func populate_full_palette() -> void:
         elif item.preview is Texture2D:
             preview = TextureRect.new()
             preview.texture = item.preview
+		elif item.mesh is Mesh:
+			preview = TextureRect.new()
+			preview.texture = EditorInterface.make_mesh_previews([item.mesh], 128)[0]
         else:
             push_error("invalid type for item.preview: ", item)
 

--- a/demo/addons/hex_map/gui/palette.gd
+++ b/demo/addons/hex_map/gui/palette.gd
@@ -227,12 +227,6 @@ func populate_compact_palette() -> void:
             button.color = Color.TRANSPARENT
             button.selected = id == selected_id
             button.tooltip_text = item.desc
-        elif item.mesh is Mesh:
-			button = PaletteChip.new()
-			button.preview = EditorInterface.make_mesh_previews([item.mesh], 128)[0]
-			button.color = Color.TRANSPARENT
-			button.selected = id == selected_id
-			button.tooltip_text = item.desc
         else:
             push_error("invalid type for item.preview: ", item)
 
@@ -256,9 +250,6 @@ func populate_full_palette() -> void:
         elif item.preview is Texture2D:
             preview = TextureRect.new()
             preview.texture = item.preview
-		elif item.mesh is Mesh:
-			preview = TextureRect.new()
-			preview.texture = EditorInterface.make_mesh_previews([item.mesh], 128)[0]
         else:
             push_error("invalid type for item.preview: ", item)
 


### PR DESCRIPTION
Fixes #41
Uses the built-in Godot editor method to auto-generate a preview texture from the Mesh instance, just like the MeshLibrary uses.

<img width="1740" height="1558" alt="image" src="https://github.com/user-attachments/assets/cd4fdd9a-921a-4b1c-b483-d395eff9c590" />

I tested with the HexMapTiled instance and my own MeshLibrary using the KayKit medieval hexagons. I'm not sure how to trigger the palette chips to test that code-path though.

I'm using Godot 4.7.1 and this works fine just patching the .gd files themselves from the last release.